### PR TITLE
Use Network set in Profiles as best practice

### DIFF
--- a/Populate_HPE_Synergy.ps1
+++ b/Populate_HPE_Synergy.ps1
@@ -320,8 +320,8 @@ function Create_Server_Profile_Template_SY480_Gen9_RHEL_Local_Boot
     $EnclGroup         = Get-HPOVEnclosureGroup -Name "EG-Synergy-Local" -ErrorAction Stop
     $Eth1              = Get-HPOVNetworkSet -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 1 -Name 'Prod-NetworkSet-1' -PortId "Mezz 3:1-c"
     $Eth2              = Get-HPOVNetworkset -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 2 -Name 'Prod-NetworkSet-2' -PortId "Mezz 3:2-c"
-    $Deploy1           = Get-HPOVNetwork -Name "Deployment" | New-HPOVServerProfileConnection -ConnectionID 3 -Name 'Deployment Network A' -PortId "Mezz 3:1-a" -Bootable -Priority Primary
-    $Deploy2           = Get-HPOVNetwork -Name "Deployment" | New-HPOVServerProfileConnection -ConnectionID 4 -Name 'Deployment Network B' -PortId "Mezz 3:2-a" -Bootable -Priority Secondary
+    $Deploy1           = Get-HPOVNetwork -Name "Deployment" | New-HPOVServerProfileConnection -ConnectionID 3 -Name 'Deployment Network A' -PortId "Mezz 3:1-a" #-Bootable -Priority Primary
+    $Deploy2           = Get-HPOVNetwork -Name "Deployment" | New-HPOVServerProfileConnection -ConnectionID 4 -Name 'Deployment Network B' -PortId "Mezz 3:2-a" #-Bootable -Priority Secondary
     $LogicalDisk       = New-HPOVServerProfileLogicalDisk -Name "SAS RAID1 SSD" -RAID RAID1 -NumberofDrives 2 -DriveType SASSSD -Bootable $True
     $StorageController = New-HPOVServerProfileLogicalDiskController -ControllerID Embedded -Mode RAID -Initialize -LogicalDisk $LogicalDisk
 

--- a/Populate_HPE_Synergy.ps1
+++ b/Populate_HPE_Synergy.ps1
@@ -3,7 +3,7 @@
 #
 # - Example script for configuring the HPE Synergy Appliance
 #
-#   VERSION 5.20
+#   VERSION 5.0
 #
 #   AUTHORS
 #   Dave Olker - HPE Storage and Big Data
@@ -31,16 +31,17 @@ THE SOFTWARE.
 #>
 
 # ------------------ Parameters
-Param ( [String]$OVApplianceIP = "192.168.62.128",
-    [String]$OVAdminName = "Administrator",
-    [String]$OVAuthDomain = "Local",
-    [String]$OneViewModule = "HPOneView.520"
+Param ( [String]$OVApplianceIP                  = "192.168.62.128",
+        [String]$OVAdminName                    = "Administrator",
+        [String]$OVAuthDomain                   = "Local",
+        [String]$OneViewModule                  = "HPOneView.500"
 )
 
 
-function Add_Remote_Enclosures {
+function Add_Remote_Enclosures
+{
     Write-Output "Adding Remote Enclosures" | Timestamp
-    Send-HPOVRequest -uri "/rest/enclosures" -method POST -body @{'hostname' = 'fe80::2:0:9:7%eth2' } | Wait-HPOVTaskComplete
+    Send-HPOVRequest -uri "/rest/enclosures" -method POST -body @{'hostname' = 'fe80::2:0:9:7%eth2'} | Wait-HPOVTaskComplete
     Write-Output "Remote Enclosures Added" | Timestamp
     #
     # Sleep for 10 seconds to allow remote enclosures to quiesce
@@ -49,7 +50,8 @@ function Add_Remote_Enclosures {
 }
 
 
-function Configure_Address_Pools {
+function Configure_Address_Pools
+{
     Write-Output "Configuring Address Pools for MAC, WWN, and Serial Numbers" | Timestamp
     New-HPOVAddressPoolRange -PoolType vmac -RangeType Generated
     New-HPOVAddressPoolRange -PoolType vwwn -RangeType Generated
@@ -58,7 +60,8 @@ function Configure_Address_Pools {
 }
 
 
-function Configure_SAN_Managers {
+function Configure_SAN_Managers
+{
     Write-Output "Configuring SAN Managers" | Timestamp
     Add-HPOVSanManager -Hostname 172.18.20.1 -SnmpUserName dcs-SHA-AES128 -SnmpAuthLevel AuthAndPriv -SnmpAuthPassword dcsdcsdcs -SnmpAuthProtocol sha -SnmpPrivPassword dcsdcsdcs -SnmpPrivProtocol aes-128 -Type Cisco -Port 161 | Wait-HPOVTaskComplete
     Add-HPOVSanManager -Hostname 172.18.20.2 -SnmpUserName dcs-SHA-AES128 -SnmpAuthLevel AuthAndPriv -SnmpAuthPassword dcsdcsdcs -SnmpAuthProtocol sha -SnmpPrivPassword dcsdcsdcs -SnmpPrivProtocol aes-128 -Type Cisco -Port 161 | Wait-HPOVTaskComplete
@@ -66,10 +69,10 @@ function Configure_SAN_Managers {
 }
 
 
-function Configure_Networks {
+function Configure_Networks
+{
     Write-Output "Adding IPv4 Subnets" | Timestamp
-    #New-HPOVAddressPoolSubnet -Domain "mgmt.lan" -Gateway $prod_gateway -NetworkId $prod_subnet -SubnetMask $prod_mask
-    Get-HPOVAddressPoolSubnet -NetworkId $prod_subnet | Set-HPOVAddressPoolSubnet -Domain "mgmt.lan" 
+    New-HPOVAddressPoolSubnet -Domain "mgmt.lan" -Gateway $prod_gateway -NetworkId $prod_subnet -SubnetMask $prod_mask
     New-HPOVAddressPoolSubnet -Domain "deployment.lan" -Gateway $deploy_gateway -NetworkId $deploy_subnet -SubnetMask $deploy_mask
 
     Write-Output "Adding IPv4 Address Pool Ranges" | Timestamp
@@ -106,14 +109,15 @@ function Configure_Networks {
 }
 
 
-function Add_Storage {
+function Add_Storage
+{
     Write-Output "Adding 3PAR Storage Systems" | Timestamp
     Add-HPOVStorageSystem -Hostname 172.18.11.11 -Password dcs -Username dcs -Domain TestDomain | Wait-HPOVTaskComplete
     Add-HPOVStorageSystem -Hostname 172.18.11.12 -Password dcs -Username dcs -Domain TestDomain | Wait-HPOVTaskComplete
 
     Write-Output "Adding 3PAR Storage Pools" | Timestamp
     $SPNames = @("CPG-SSD", "CPG-SSD-AO", "CPG_FC-AO", "FST_CPG1", "FST_CPG2")
-    for ($i = 0; $i -lt $SPNames.Length; $i++) {
+    for ($i=0; $i -lt $SPNames.Length; $i++) {
         Get-HPOVStoragePool -Name $SPNames[$i] -ErrorAction Stop | Set-HPOVStoragePool -Managed $true | Wait-HPOVTaskComplete
     }
     
@@ -145,7 +149,8 @@ function Add_Storage {
 }
 
 
-function Rename_Enclosures {
+function Rename_Enclosures
+{
     Write-Output "Renaming Enclosures" | Timestamp
     $Enc = Get-HPOVEnclosure -Name 0000A66101 -ErrorAction SilentlyContinue
     Set-HPOVEnclosure -Name Synergy-Encl-1 -Enclosure $Enc | Wait-HPOVTaskComplete
@@ -166,7 +171,8 @@ function Rename_Enclosures {
 }
 
 
-function Create_Uplink_Sets {
+function Create_Uplink_Sets
+{
     Write-Output "Adding Fibre Channel and FCoE Uplink Sets" | Timestamp
     $LIGFlex = Get-HPOVLogicalInterconnectGroup -Name "LIG-FlexFabric"
     $SAN_A_FC = Get-HPOVNetwork -Name "SAN A FC"
@@ -187,45 +193,48 @@ function Create_Uplink_Sets {
     Write-Output "Adding FlexFabric Uplink Sets" | Timestamp
     $LIGFlex = Get-HPOVLogicalInterconnectGroup -Name "LIG-FlexFabric"
     $ESX_Mgmt = Get-HPOVNetwork -Name "ESX Mgmt"
-    New-HPOVUplinkSet -Resource $LIGFlex -Name "US-ESX-Mgmt" -Type Ethernet -Networks $ESX_Mgmt -UplinkPorts "Enclosure1:Bay3:Q1.2", "Enclosure2:Bay6:Q1.2" | Wait-HPOVTaskComplete
+    New-HPOVUplinkSet -Resource $LIGFlex -Name "US-ESX-Mgmt" -Type Ethernet -Networks $ESX_Mgmt -UplinkPorts "Enclosure1:Bay3:Q1.2","Enclosure2:Bay6:Q1.2" | Wait-HPOVTaskComplete
 
     $LIGFlex = Get-HPOVLogicalInterconnectGroup -Name "LIG-FlexFabric"
     $ESX_vMotion = Get-HPOVNetwork -Name "ESX vMotion"
-    New-HPOVUplinkSet -Resource $LIGFlex -Name "US-ESX-vMotion" -Type Ethernet -Networks $ESX_vMotion -UplinkPorts "Enclosure1:Bay3:Q1.3", "Enclosure2:Bay6:Q1.3" | Wait-HPOVTaskComplete
+    New-HPOVUplinkSet -Resource $LIGFlex -Name "US-ESX-vMotion" -Type Ethernet -Networks $ESX_vMotion -UplinkPorts "Enclosure1:Bay3:Q1.3","Enclosure2:Bay6:Q1.3" | Wait-HPOVTaskComplete
 
     $LIGFlex = Get-HPOVLogicalInterconnectGroup -Name "LIG-FlexFabric"
     $Prod_Nets = Get-HPOVNetwork -Name "Prod*"
-    New-HPOVUplinkSet -Resource $LIGFlex -Name "US-Prod" -Type Ethernet -Networks $Prod_Nets -UplinkPorts "Enclosure1:Bay3:Q1.4", "Enclosure2:Bay6:Q1.4" | Wait-HPOVTaskComplete
+    New-HPOVUplinkSet -Resource $LIGFlex -Name "US-Prod" -Type Ethernet -Networks $Prod_Nets -UplinkPorts "Enclosure1:Bay3:Q1.4","Enclosure2:Bay6:Q1.4" | Wait-HPOVTaskComplete
 
-    # Write-Output "Adding ImageStreamer Uplink Sets" | Timestamp
-    # $ImageStreamerDeploymentNetworkObject = Get-HPOVNetwork -Name "Deployment" -ErrorAction Stop
-    # Get-HPOVLogicalInterconnectGroup -Name "LIG-FlexFabric" -ErrorAction Stop | New-HPOVUplinkSet -Name "US-Image Streamer" -Type ImageStreamer -Networks $ImageStreamerDeploymentNetworkObject -UplinkPorts "Enclosure1:Bay3:Q5.1", "Enclosure1:Bay3:Q6.1", "Enclosure2:Bay6:Q5.1", "Enclosure2:Bay6:Q6.1" | Wait-HPOVTaskComplete
+    Write-Output "Adding ImageStreamer Uplink Sets" | Timestamp
+    $ImageStreamerDeploymentNetworkObject = Get-HPOVNetwork -Name "Deployment" -ErrorAction Stop
+    Get-HPOVLogicalInterconnectGroup -Name "LIG-FlexFabric" -ErrorAction Stop | New-HPOVUplinkSet -Name "US-Image Streamer" -Type ImageStreamer -Networks $ImageStreamerDeploymentNetworkObject -UplinkPorts "Enclosure1:Bay3:Q5.1","Enclosure1:Bay3:Q6.1","Enclosure2:Bay6:Q5.1","Enclosure2:Bay6:Q6.1" | Wait-HPOVTaskComplete
 
     Write-Output "All Uplink Sets Configured" | Timestamp
 }
 
 
-function Create_Enclosure_Group {
+function Create_Enclosure_Group
+{
     $3FrameVCLIG = Get-HPOVLogicalInterconnectGroup -Name LIG-FlexFabric
     $SasLIG = Get-HPOVLogicalInterconnectGroup -Name LIG-SAS
     $FcLIG = Get-HPOVLogicalInterconnectGroup -Name LIG-FC
-    New-HPOVEnclosureGroup -name "EG-Synergy-Local" -LogicalInterconnectGroupMapping @{Frame1 = $3FrameVCLIG, $SasLIG, $FcLIG; Frame2 = $3FrameVCLIG, $SasLIG, $FcLIG; Frame3 = $3FrameVCLIG, $SasLIG, $FcLIG } -EnclosureCount 3 -IPv4AddressType External # -DeploymentNetworkType Internal
+    New-HPOVEnclosureGroup -name "EG-Synergy-Local" -LogicalInterconnectGroupMapping @{Frame1 = $3FrameVCLIG,$SasLIG,$FcLIG; Frame2 = $3FrameVCLIG,$SasLIG,$FcLIG; Frame3 = $3FrameVCLIG,$SasLIG,$FcLIG} -EnclosureCount 3 -IPv4AddressType External -DeploymentNetworkType Internal
 
     Write-Output "Enclosure Group Created" | Timestamp
 }
 
 
-function Create_Enclosure_Group_Remote {
+function Create_Enclosure_Group_Remote
+{
     $2FrameVCLIG_1 = Get-HPOVLogicalInterconnectGroup -Name LIG-FlexFabric-Remote-1
     $2FrameVCLIG_2 = Get-HPOVLogicalInterconnectGroup -Name LIG-FlexFabric-Remote-2
     $FcLIG = Get-HPOVLogicalInterconnectGroup -Name LIG-FC-Remote
-    New-HPOVEnclosureGroup -name "EG-Synergy-Remote" -LogicalInterconnectGroupMapping @{Frame1 = $FcLIG, $2FrameVCLIG_1, $2FrameVCLIG_2; Frame2 = $FcLIG, $2FrameVCLIG_1, $2FrameVCLIG_2 } -EnclosureCount 2
+    New-HPOVEnclosureGroup -name "EG-Synergy-Remote" -LogicalInterconnectGroupMapping @{Frame1 = $FcLIG,$2FrameVCLIG_1,$2FrameVCLIG_2; Frame2 = $FcLIG,$2FrameVCLIG_1,$2FrameVCLIG_2} -EnclosureCount 2
 
     Write-Output "Enclosure Group Created" | Timestamp
 }
 
 
-function Create_Logical_Enclosure {
+function Create_Logical_Enclosure
+{
     Write-Output "Creating Local Logical Enclosure" | Timestamp
     $EG = Get-HPOVEnclosureGroup -Name EG-Synergy-Local
     $Encl = Get-HPOVEnclosure -Name Synergy-Encl-1
@@ -234,7 +243,8 @@ function Create_Logical_Enclosure {
 }
 
 
-function Create_Logical_Enclosure_Remote {
+function Create_Logical_Enclosure_Remote
+{
     Write-Output "Creating Remote Logical Enclosure" | Timestamp
     $EG = Get-HPOVEnclosureGroup -Name EG-Synergy-Remote
     $Encl = Get-HPOVEnclosure -Name Synergy-Encl-4
@@ -243,25 +253,28 @@ function Create_Logical_Enclosure_Remote {
 }
 
 
-function Create_Logical_Interconnect_Groups {
+function Create_Logical_Interconnect_Groups
+{
     Write-Output "Creating Local Logical Interconnect Groups" | Timestamp
-    New-HPOVLogicalInterconnectGroup -Name "LIG-SAS" -FrameCount 1 -InterconnectBaySet 1 -FabricModuleType "SAS" -Bays @{Frame1 = @{Bay1 = "SE12SAS" ; Bay4 = "SE12SAS" } }
-    New-HPOVLogicalInterconnectGroup -Name "LIG-FC" -FrameCount 1 -InterconnectBaySet 2 -FabricModuleType "SEVCFC" -Bays @{Frame1 = @{Bay2 = "SEVC16GbFC" ; Bay5 = "SEVC16GbFC" } }
-    New-HPOVLogicalInterconnectGroup -Name "LIG-FlexFabric" -FrameCount 3 -InterconnectBaySet 3 -FabricModuleType "SEVC40F8" -Bays @{Frame1 = @{Bay3 = "SEVC40f8" ; Bay6 = "SE20ILM" }; Frame2 = @{Bay3 = "SE20ILM"; Bay6 = "SEVC40f8" }; Frame3 = @{Bay3 = "SE20ILM"; Bay6 = "SE20ILM" } } -FabricRedundancy "HighlyAvailable"
+    New-HPOVLogicalInterconnectGroup -Name "LIG-SAS" -FrameCount 1 -InterconnectBaySet 1 -FabricModuleType "SAS" -Bays @{Frame1 = @{Bay1 = "SE12SAS" ; Bay4 = "SE12SAS"}}
+    New-HPOVLogicalInterconnectGroup -Name "LIG-FC" -FrameCount 1 -InterconnectBaySet 2 -FabricModuleType "SEVCFC" -Bays @{Frame1 = @{Bay2 = "SEVC16GbFC" ; Bay5 = "SEVC16GbFC"}}
+    New-HPOVLogicalInterconnectGroup -Name "LIG-FlexFabric" -FrameCount 3 -InterconnectBaySet 3 -FabricModuleType "SEVC40F8" -Bays @{Frame1 = @{Bay3 = "SEVC40f8" ; Bay6 = "SE20ILM"};Frame2 = @{Bay3 = "SE20ILM"; Bay6 = "SEVC40f8" };Frame3 = @{Bay3 = "SE20ILM"; Bay6 = "SE20ILM"}} -FabricRedundancy "HighlyAvailable"
     Write-Output "Logical Interconnect Groups Created" | Timestamp
 }
 
 
-function Create_Logical_Interconnect_Groups_Remote {
+function Create_Logical_Interconnect_Groups_Remote
+{
     Write-Output "Creating Remote Logical Interconnect Groups" | Timestamp
-    New-HPOVLogicalInterconnectGroup -Name "LIG-FC-Remote" -FrameCount 1 -InterconnectBaySet 1 -FabricModuleType "SEVCFC" -Bays @{Frame1 = @{Bay1 = "SEVC16GbFC" ; Bay4 = "SEVC16GbFC" } }
-    New-HPOVLogicalInterconnectGroup -Name "LIG-FlexFabric-Remote-1" -FrameCount 2 -InterconnectBaySet 2 -FabricModuleType "SEVC40F8" -Bays @{Frame1 = @{Bay2 = "SEVC40f8" ; Bay5 = "SE20ILM" }; Frame2 = @{Bay2 = "SE20ILM"; Bay5 = "SEVC40F8" } } -FabricRedundancy "HighlyAvailable"
-    New-HPOVLogicalInterconnectGroup -Name "LIG-FlexFabric-Remote-2" -FrameCount 2 -InterconnectBaySet 3 -FabricModuleType "SEVC40F8" -Bays @{Frame1 = @{Bay3 = "SEVC40f8" ; Bay6 = "SE20ILM" }; Frame2 = @{Bay3 = "SE20ILM"; Bay6 = "SEVC40F8" } } -FabricRedundancy "HighlyAvailable"
+    New-HPOVLogicalInterconnectGroup -Name "LIG-FC-Remote" -FrameCount 1 -InterconnectBaySet 1 -FabricModuleType "SEVCFC" -Bays @{Frame1 = @{Bay1 = "SEVC16GbFC" ; Bay4 = "SEVC16GbFC"}}
+    New-HPOVLogicalInterconnectGroup -Name "LIG-FlexFabric-Remote-1" -FrameCount 2 -InterconnectBaySet 2 -FabricModuleType "SEVC40F8" -Bays @{Frame1 = @{Bay2 = "SEVC40f8" ; Bay5 = "SE20ILM"};Frame2 = @{Bay2 = "SE20ILM"; Bay5 = "SEVC40F8" }} -FabricRedundancy "HighlyAvailable"
+    New-HPOVLogicalInterconnectGroup -Name "LIG-FlexFabric-Remote-2" -FrameCount 2 -InterconnectBaySet 3 -FabricModuleType "SEVC40F8" -Bays @{Frame1 = @{Bay3 = "SEVC40f8" ; Bay6 = "SE20ILM"};Frame2 = @{Bay3 = "SE20ILM"; Bay6 = "SEVC40F8" }} -FabricRedundancy "HighlyAvailable"
     Write-Output "Logical Interconnect Groups Created" | Timestamp
 }
 
 
-function Add_Licenses {
+function Add_Licenses
+{
     Write-Output "Adding OneView and Synergy FC Licenses" | Timestamp
 
     $License_File = Read-Host -Prompt "Optional: Enter Filename Containing OneView and Synergy FC Licenses"
@@ -273,7 +286,8 @@ function Add_Licenses {
 }
 
 
-function Add_Firmware_Bundle {
+function Add_Firmware_Bundle
+{
     Write-Output "Adding Firmware Bundles" | Timestamp
     $firmware_bundle = Read-Host "Optional: Specify location of Service Pack for ProLiant ISO file"
     if ($firmware_bundle) {
@@ -289,7 +303,8 @@ function Add_Firmware_Bundle {
 }
 
 
-function Create_OS_Deployment_Server {
+function Create_OS_Deployment_Server
+{
     Write-Output "Configuring OS Deployment Servers" | Timestamp
     $ManagementNetwork = Get-HPOVNetwork -Type Ethernet -Name "Mgmt"
     Get-HPOVImageStreamerAppliance | Select-Object -First 1 | New-HPOVOSDeploymentServer -Name "LE1 Image Streamer" -ManagementNetwork $ManagementNetwork -Description "Image Streamer for Logical Enclosure 1" | Wait-HPOVTaskComplete
@@ -297,16 +312,17 @@ function Create_OS_Deployment_Server {
 }
 
 
-function Create_Server_Profile_Template_SY480_Gen9_RHEL_Local_Boot {
+function Create_Server_Profile_Template_SY480_Gen9_RHEL_Local_Boot
+{
     Write-Output "Creating SY480 Gen9 with Local Boot for RHEL Server Profile Template" | Timestamp
 
-    $SHT = Get-HPOVServerHardwareTypes -Name "SY 480 Gen9 1" -ErrorAction Stop
-    $EnclGroup = Get-HPOVEnclosureGroup -Name "EG-Synergy-Local" -ErrorAction Stop
-    $Eth1 = Get-HPOVNetworkSet -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 1 -Name 'Prod-NetworkSet-1' -PortId "Mezz 3:1-c"
-    $Eth2 = Get-HPOVNetworkset -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 2 -Name 'Prod-NetworkSet-2' -PortId "Mezz 3:2-c"
-    $Deploy1 = Get-HPOVNetwork -Name "Deployment" | New-HPOVServerProfileConnection -ConnectionID 3 -Name 'Deployment Network A' -PortId "Mezz 3:1-a" #-Bootable -Priority Primary
-    $Deploy2 = Get-HPOVNetwork -Name "Deployment" | New-HPOVServerProfileConnection -ConnectionID 4 -Name 'Deployment Network B' -PortId "Mezz 3:2-a" #-Bootable -Priority Secondary
-    $LogicalDisk = New-HPOVServerProfileLogicalDisk -Name "SAS RAID1 SSD" -RAID RAID1 -NumberofDrives 2 -DriveType SASSSD -Bootable $True
+    $SHT               = Get-HPOVServerHardwareTypes -Name "SY 480 Gen9 1" -ErrorAction Stop
+    $EnclGroup         = Get-HPOVEnclosureGroup -Name "EG-Synergy-Local" -ErrorAction Stop
+    $Eth1              = Get-HPOVNetworkSet -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 1 -Name 'Prod-NetworkSet-1' -PortId "Mezz 3:1-c"
+    $Eth2              = Get-HPOVNetworkset -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 2 -Name 'Prod-NetworkSet-2' -PortId "Mezz 3:2-c"
+    $Deploy1           = Get-HPOVNetwork -Name "Deployment" | New-HPOVServerProfileConnection -ConnectionID 3 -Name 'Deployment Network A' -PortId "Mezz 3:1-a" #-Bootable -Priority Primary
+    $Deploy2           = Get-HPOVNetwork -Name "Deployment" | New-HPOVServerProfileConnection -ConnectionID 4 -Name 'Deployment Network B' -PortId "Mezz 3:2-a" #-Bootable -Priority Secondary
+    $LogicalDisk       = New-HPOVServerProfileLogicalDisk -Name "SAS RAID1 SSD" -RAID RAID1 -NumberofDrives 2 -DriveType SASSSD -Bootable $True
     $StorageController = New-HPOVServerProfileLogicalDiskController -ControllerID Embedded -Mode RAID -Initialize -LogicalDisk $LogicalDisk
 
     $params = @{
@@ -335,12 +351,13 @@ function Create_Server_Profile_Template_SY480_Gen9_RHEL_Local_Boot {
 }
 
 
-function Create_Server_Profile_SY480_Gen9_RHEL_Local_Boot {
+function Create_Server_Profile_SY480_Gen9_RHEL_Local_Boot
+{
     Write-Output "Creating SY480 Gen9 Local Boot for RHEL Server Profile" | Timestamp
 
-    $SHT = Get-HPOVServerHardwareTypes -Name "SY 480 Gen9 1" -ErrorAction Stop
-    $Template = Get-HPOVServerProfileTemplate -Name "HPE Synergy 480 Gen9 with Local Boot for RHEL Template" -ErrorAction Stop
-    $Server = Get-HPOVServer -ServerHardwareType $SHT -NoProfile -ErrorAction Stop | Select-Object -First 1
+    $SHT            = Get-HPOVServerHardwareTypes -Name "SY 480 Gen9 1" -ErrorAction Stop
+    $Template       = Get-HPOVServerProfileTemplate -Name "HPE Synergy 480 Gen9 with Local Boot for RHEL Template" -ErrorAction Stop
+    $Server         = Get-HPOVServer -ServerHardwareType $SHT -NoProfile -ErrorAction Stop | Select-Object -First 1
 
     $params = @{
         AssignmentType        = "Server";
@@ -355,17 +372,18 @@ function Create_Server_Profile_SY480_Gen9_RHEL_Local_Boot {
 }
 
 
-function Create_Server_Profile_Template_SY660_Gen9_Windows_SAN_Storage {
+function Create_Server_Profile_Template_SY660_Gen9_Windows_SAN_Storage
+{
     Write-Output "Creating SY660 Gen9 with Local Boot and SAN Storage for Windows Server Profile Template" | Timestamp
 
-    $SHT = Get-HPOVServerHardwareTypes -Name "SY 660 Gen9 1" -ErrorAction Stop
-    $EnclGroup = Get-HPOVEnclosureGroup -Name "EG-Synergy-Local" -ErrorAction Stop
-    $Eth1 = Get-HPOVNetworkSet -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 1 -Name 'Prod-NetworkSet-1' -PortId "Mezz 3:1-c"
-    $Eth2 = Get-HPOVNetworkset -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 2 -Name 'Prod-NetworkSet-2' -PortId "Mezz 3:2-c"
-    $FC1 = Get-HPOVNetwork -Name 'SAN A FC' | New-HPOVServerProfileConnection -connectionId 3
-    $FC2 = Get-HPOVNetwork -Name 'SAN B FC' | New-HPOVServerProfileConnection -connectionId 4
-    $LogicalDisk = New-HPOVServerProfileLogicalDisk -Name "SAS RAID5 SSD" -RAID RAID5 -NumberofDrives 3 -DriveType SASSSD -Bootable $True
-    $SANVol = Get-HPOVStorageVolume -Name "Shared-Volume-2" | New-HPOVServerProfileAttachVolume -VolumeID 1
+    $SHT               = Get-HPOVServerHardwareTypes -Name "SY 660 Gen9 1" -ErrorAction Stop
+    $EnclGroup         = Get-HPOVEnclosureGroup -Name "EG-Synergy-Local" -ErrorAction Stop
+    $Eth1              = Get-HPOVNetworkSet -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 1 -Name 'Prod-NetworkSet-1' -PortId "Mezz 3:1-c"
+    $Eth2              = Get-HPOVNetworkset -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 2 -Name 'Prod-NetworkSet-2' -PortId "Mezz 3:2-c"
+    $FC1               = Get-HPOVNetwork -Name 'SAN A FC' | New-HPOVServerProfileConnection -connectionId 3
+    $FC2               = Get-HPOVNetwork -Name 'SAN B FC' | New-HPOVServerProfileConnection -connectionId 4
+    $LogicalDisk       = New-HPOVServerProfileLogicalDisk -Name "SAS RAID5 SSD" -RAID RAID5 -NumberofDrives 3 -DriveType SASSSD -Bootable $True
+    $SANVol            = Get-HPOVStorageVolume -Name "Shared-Volume-2" | New-HPOVServerProfileAttachVolume -VolumeID 1
     $StorageController = New-HPOVServerProfileLogicalDiskController -ControllerID Embedded -Mode RAID -Initialize -LogicalDisk $LogicalDisk
 
     $params = @{
@@ -394,12 +412,13 @@ function Create_Server_Profile_Template_SY660_Gen9_Windows_SAN_Storage {
 }
 
 
-function Create_Server_Profile_SY660_Gen9_Windows_SAN_Storage {
+function Create_Server_Profile_SY660_Gen9_Windows_SAN_Storage
+{
     Write-Output "Creating SY660 Gen9 with Local Boot and SAN Storage for Windows Server Profile" | Timestamp
 
-    $SHT = Get-HPOVServerHardwareTypes -Name "SY 660 Gen9 1" -ErrorAction Stop
-    $Template = Get-HPOVServerProfileTemplate -Name "HPE Synergy 660 Gen9 with Local Boot and SAN Storage for Windows Template" -ErrorAction Stop
-    $Server = Get-HPOVServer -ServerHardwareType $SHT -NoProfile -ErrorAction Stop | Select-Object -First 1
+    $SHT            = Get-HPOVServerHardwareTypes -Name "SY 660 Gen9 1" -ErrorAction Stop
+    $Template       = Get-HPOVServerProfileTemplate -Name "HPE Synergy 660 Gen9 with Local Boot and SAN Storage for Windows Template" -ErrorAction Stop
+    $Server         = Get-HPOVServer -ServerHardwareType $SHT -NoProfile -ErrorAction Stop | Select-Object -First 1
 
     $params = @{
         AssignmentType        = "Server";
@@ -414,17 +433,18 @@ function Create_Server_Profile_SY660_Gen9_Windows_SAN_Storage {
 }
 
 
-function Create_Server_Profile_Template_SY480_Gen9_ESX_SAN_Boot {
+function Create_Server_Profile_Template_SY480_Gen9_ESX_SAN_Boot
+{
     Write-Output "Creating SY480 Gen9 with SAN Boot for ESX Server Profile Template" | Timestamp
 
-    $SHT = Get-HPOVServerHardwareTypes -Name "SY 480 Gen9 2" -ErrorAction Stop
-    $EnclGroup = Get-HPOVEnclosureGroup -Name "EG-Synergy-Local" -ErrorAction Stop
-    $Eth1 = Get-HPOVNetworkSet -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 1 -Name 'Prod-NetworkSet-1' -PortId "Mezz 3:1-c"
-    $Eth2 = Get-HPOVNetworkset -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 2 -Name 'Prod-NetworkSet-2' -PortId "Mezz 3:2-c"
-    $FC1 = Get-HPOVNetwork -Name 'SAN A FC' | New-HPOVServerProfileConnection -ConnectionID 3 -Bootable -Priority Primary -BootVolumeSource ManagedVolume -ConnectionType FibreChannel
-    $FC2 = Get-HPOVNetwork -Name 'SAN B FC' | New-HPOVServerProfileConnection -ConnectionID 4 -Bootable -Priority Secondary -BootVolumeSource ManagedVolume -ConnectionType FibreChannel
-    $StoragePool = Get-HPOVStoragePool -Name FST_CPG1 -StorageSystem ThreePAR-1 -ErrorAction Stop
-    $SANVol = New-HPOVServerProfileAttachVolume -Name BootVol -StoragePool $StoragePool -BootVolume -Capacity 100 -LunIdType Auto
+    $SHT               = Get-HPOVServerHardwareTypes -Name "SY 480 Gen9 2" -ErrorAction Stop
+    $EnclGroup         = Get-HPOVEnclosureGroup -Name "EG-Synergy-Local" -ErrorAction Stop
+    $Eth1              = Get-HPOVNetworkSet -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 1 -Name 'Prod-NetworkSet-1' -PortId "Mezz 3:1-c"
+    $Eth2              = Get-HPOVNetworkset -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 2 -Name 'Prod-NetworkSet-2' -PortId "Mezz 3:2-c"
+    $FC1               = Get-HPOVNetwork -Name 'SAN A FC' | New-HPOVServerProfileConnection -ConnectionID 3 -Bootable -Priority Primary -BootVolumeSource ManagedVolume -ConnectionType FibreChannel
+    $FC2               = Get-HPOVNetwork -Name 'SAN B FC' | New-HPOVServerProfileConnection -ConnectionID 4 -Bootable -Priority Secondary -BootVolumeSource ManagedVolume -ConnectionType FibreChannel
+    $StoragePool       = Get-HPOVStoragePool -Name FST_CPG1 -StorageSystem ThreePAR-1 -ErrorAction Stop
+    $SANVol            = New-HPOVServerProfileAttachVolume -Name BootVol -StoragePool $StoragePool -BootVolume -Capacity 100 -LunIdType Auto
 
     $params = @{
         Affinity                 = "Bay";
@@ -451,12 +471,13 @@ function Create_Server_Profile_Template_SY480_Gen9_ESX_SAN_Boot {
 }
 
 
-function Create_Server_Profile_SY480_Gen9_ESX_SAN_Boot {
+function Create_Server_Profile_SY480_Gen9_ESX_SAN_Boot
+{
     Write-Output "Creating SY480 Gen9 SAN Boot for ESX Server Profile" | Timestamp
 
-    $SHT = Get-HPOVServerHardwareTypes -Name "SY 480 Gen9 2" -ErrorAction Stop
-    $Template = Get-HPOVServerProfileTemplate -Name "HPE Synergy 480 Gen9 with SAN Boot for ESX Template" -ErrorAction Stop
-    $Server = Get-HPOVServer -ServerHardwareType $SHT -NoProfile -ErrorAction Stop | Select-Object -First 1
+    $SHT            = Get-HPOVServerHardwareTypes -Name "SY 480 Gen9 2" -ErrorAction Stop
+    $Template       = Get-HPOVServerProfileTemplate -Name "HPE Synergy 480 Gen9 with SAN Boot for ESX Template" -ErrorAction Stop
+    $Server         = Get-HPOVServer -ServerHardwareType $SHT -NoProfile -ErrorAction Stop | Select-Object -First 1
 
     $params = @{
         AssignmentType        = "Server";
@@ -471,17 +492,18 @@ function Create_Server_Profile_SY480_Gen9_ESX_SAN_Boot {
 }
 
 
-function Create_Server_Profile_Template_SY480_Gen10_ESX_SAN_Boot {
+function Create_Server_Profile_Template_SY480_Gen10_ESX_SAN_Boot
+{
     Write-Output "Creating SY480 Gen10 with SAN Boot for ESX Server Profile Template" | Timestamp
 
-    $SHT = Get-HPOVServerHardwareTypes -Name "SY 480 Gen10 1" -ErrorAction Stop
-    $EnclGroup = Get-HPOVEnclosureGroup -Name "EG-Synergy-Local" -ErrorAction Stop
-    $Eth1 = Get-HPOVNetworkSet -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 1 -Name 'Prod-NetworkSet-1' -PortId "Mezz 3:1-c"
-    $Eth2 = Get-HPOVNetworkset -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 2 -Name 'Prod-NetworkSet-2' -PortId "Mezz 3:2-c"
-    $FC1 = Get-HPOVNetwork -Name 'SAN A FC' | New-HPOVServerProfileConnection -ConnectionID 3 -Bootable -Priority Primary -BootVolumeSource ManagedVolume -ConnectionType FibreChannel
-    $FC2 = Get-HPOVNetwork -Name 'SAN B FC' | New-HPOVServerProfileConnection -ConnectionID 4 -Bootable -Priority Secondary -BootVolumeSource ManagedVolume -ConnectionType FibreChannel
-    $StoragePool = Get-HPOVStoragePool -Name FST_CPG1 -StorageSystem ThreePAR-2 -ErrorAction Stop
-    $SANVol = New-HPOVServerProfileAttachVolume -Name BootVol-Gen10 -StoragePool $StoragePool -BootVolume -Capacity 100 -LunIdType Auto
+    $SHT               = Get-HPOVServerHardwareTypes -Name "SY 480 Gen10 1" -ErrorAction Stop
+    $EnclGroup         = Get-HPOVEnclosureGroup -Name "EG-Synergy-Local" -ErrorAction Stop
+    $Eth1              = Get-HPOVNetworkSet -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 1 -Name 'Prod-NetworkSet-1' -PortId "Mezz 3:1-c"
+    $Eth2              = Get-HPOVNetworkset -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 2 -Name 'Prod-NetworkSet-2' -PortId "Mezz 3:2-c"
+    $FC1               = Get-HPOVNetwork -Name 'SAN A FC' | New-HPOVServerProfileConnection -ConnectionID 3 -Bootable -Priority Primary -BootVolumeSource ManagedVolume -ConnectionType FibreChannel
+    $FC2               = Get-HPOVNetwork -Name 'SAN B FC' | New-HPOVServerProfileConnection -ConnectionID 4 -Bootable -Priority Secondary -BootVolumeSource ManagedVolume -ConnectionType FibreChannel
+    $StoragePool       = Get-HPOVStoragePool -Name FST_CPG1 -StorageSystem ThreePAR-2 -ErrorAction Stop
+    $SANVol            = New-HPOVServerProfileAttachVolume -Name BootVol-Gen10 -StoragePool $StoragePool -BootVolume -Capacity 100 -LunIdType Auto
 
     #
     # Check if firmware bundles are installed.  If there are, select the last one
@@ -510,8 +532,7 @@ function Create_Server_Profile_Template_SY480_Gen10_ESX_SAN_Boot {
             ServerProfileDescription = "Server Profile for HPE Synergy 480 Gen10 Compute Module with SAN Boot for ESX";
             StorageVolume            = $SANVol
         }
-    }
-    else {
+    } else {
         $params = @{
             Affinity                 = "Bay";
             BootMode                 = "BIOS";
@@ -537,12 +558,13 @@ function Create_Server_Profile_Template_SY480_Gen10_ESX_SAN_Boot {
 }
 
 
-function Create_Server_Profile_SY480_Gen10_ESX_SAN_Boot {
+function Create_Server_Profile_SY480_Gen10_ESX_SAN_Boot
+{
     Write-Output "Creating SY480 Gen10 SAN Boot for ESX Server Profile" | Timestamp
 
-    $SHT = Get-HPOVServerHardwareTypes -Name "SY 480 Gen10 1" -ErrorAction Stop
-    $Template = Get-HPOVServerProfileTemplate -Name "HPE Synergy 480 Gen10 with SAN Boot for ESX Template" -ErrorAction Stop
-    $Server = Get-HPOVServer -ServerHardwareType $SHT -NoProfile -ErrorAction Stop | Select-Object -First 1
+    $SHT            = Get-HPOVServerHardwareTypes -Name "SY 480 Gen10 1" -ErrorAction Stop
+    $Template       = Get-HPOVServerProfileTemplate -Name "HPE Synergy 480 Gen10 with SAN Boot for ESX Template" -ErrorAction Stop
+    $Server         = Get-HPOVServer -ServerHardwareType $SHT -NoProfile -ErrorAction Stop | Select-Object -First 1
 
     $params = @{
         AssignmentType        = "Server";
@@ -557,7 +579,8 @@ function Create_Server_Profile_SY480_Gen10_ESX_SAN_Boot {
 }
 
 
-function PowerOff_All_Servers {
+function PowerOff_All_Servers
+{
     Write-Output "Powering Off All Servers" | Timestamp
 
     $Servers = Get-HPOVServer
@@ -573,7 +596,8 @@ function PowerOff_All_Servers {
 }
 
 
-function Add_Users {
+function Add_Users
+{
     Write-Output "Adding New Users" | Timestamp
 
     New-HPOVUser -UserName BackupAdmin -FullName "Backup Administrator" -Password BackupPasswd -Roles "Backup Administrator" -EmailAddress "backup@hpe.com" -OfficePhone "(111) 111-1111" -MobilePhone "(999) 999-9999"
@@ -586,7 +610,8 @@ function Add_Users {
 }
 
 
-function Add_Scopes {
+function Add_Scopes
+{
     Write-Output "Adding New Scopes" | Timestamp
 
     New-HPOVScope -Name FinanceScope -Description "Finance Scope of Resources"
@@ -614,38 +639,43 @@ Remove-Module -ErrorAction SilentlyContinue HPOneView.310
 Remove-Module -ErrorAction SilentlyContinue HPOneView.400
 Remove-Module -ErrorAction SilentlyContinue HPOneView.410
 Remove-Module -ErrorAction SilentlyContinue HPOneView.420
-Remove-Module -ErrorAction SilentlyContinue HPOneView.500
 
-if (-not (Get-Module HPOneview.520)) {
-    Import-Module -Name HPOneView.520
+if (-not (Get-Module HPOneview.500))
+{
+    Import-Module -Name HPOneView.500
 }
 
-if (-not $ConnectedSessions) {
-    $ApplianceIP = Read-Host -Prompt "Synergy Composer IP Address [$OVApplianceIP]"
-    if ([string]::IsNullOrWhiteSpace($ApplianceIP)) {
+if (-not $ConnectedSessions)
+{
+    $ApplianceIP     = Read-Host -Prompt "Synergy Composer IP Address [$OVApplianceIP]"
+    if ([string]::IsNullOrWhiteSpace($ApplianceIP))
+    {
         $ApplianceIP = $OVApplianceIP
     }
 
-    $AdminName = Read-Host -Prompt "Administrator Username [$OVAdminName]"
-    if ([string]::IsNullOrWhiteSpace($AdminName)) {
-        $AdminName = $OVAdminName
+    $AdminName       = Read-Host -Prompt "Administrator Username [$OVAdminName]"
+    if ([string]::IsNullOrWhiteSpace($AdminName))
+    {
+        $AdminName   = $OVAdminName
     }
 
-    $AdminCred = Get-Credential -UserName $AdminName -Message "Password required for the user '$AdminName'"
-    if ([string]::IsNullOrWhiteSpace($AdminCred)) {
+    $AdminCred       = Get-Credential -UserName $AdminName -Message "Password required for the user '$AdminName'"
+    if ([string]::IsNullOrWhiteSpace($AdminCred))
+    {
         Write-Output "Blank Credential is not permitted.  Exiting."
         Exit
     }
 
     Connect-HPOVMgmt -Hostname $ApplianceIP -Credential $AdminCred -AuthLoginDomain $OVAuthDomain -ErrorAction Stop
 
-    if (-not $ConnectedSessions) {
+    if (-not $ConnectedSessions)
+    {
         Write-Output "Login to Synergy System failed.  Exiting."
         Exit
     }
 }
 
-filter Timestamp { "$(Get-Date -Format G): $_" }
+filter Timestamp {"$(Get-Date -Format G): $_"}
 
 
 ##########################################################################
@@ -660,9 +690,8 @@ if (Test-Path $config_file) {
         $var = $_.Split('=')
         New-Variable -Name $var[0] -Value $var[1] -Scope Global -Force
     }
-}
-else {
-    Write-warning "Configuration file '$config_file' not found.  Exiting."  | Timestamp
+} else {
+    Write-Output "Configuration file '$config_file' not found.  Exiting." | Timestamp
     Exit
 }
 
@@ -679,7 +708,7 @@ Configure_SAN_Managers
 Configure_Networks
 Add_Storage
 Add_Users
-# Create_OS_Deployment_Server
+Create_OS_Deployment_Server
 Create_Logical_Interconnect_Groups
 Create_Uplink_Sets
 Create_Enclosure_Group

--- a/Populate_HPE_Synergy.ps1
+++ b/Populate_HPE_Synergy.ps1
@@ -613,9 +613,10 @@ Remove-Module -ErrorAction SilentlyContinue HPOneView.310
 Remove-Module -ErrorAction SilentlyContinue HPOneView.400
 Remove-Module -ErrorAction SilentlyContinue HPOneView.410
 Remove-Module -ErrorAction SilentlyContinue HPOneView.420
+Remove-Module -ErrorAction SilentlyContinue HPOneView.500
 
-if (-not (Get-Module HPOneview.500)) {
-    Import-Module -Name HPOneView.500
+if (-not (Get-Module HPOneview.520)) {
+    Import-Module -Name HPOneView.520
 }
 
 if (-not $ConnectedSessions) {

--- a/Populate_HPE_Synergy.ps1
+++ b/Populate_HPE_Synergy.ps1
@@ -197,9 +197,9 @@ function Create_Uplink_Sets {
     $Prod_Nets = Get-HPOVNetwork -Name "Prod*"
     New-HPOVUplinkSet -Resource $LIGFlex -Name "US-Prod" -Type Ethernet -Networks $Prod_Nets -UplinkPorts "Enclosure1:Bay3:Q1.4", "Enclosure2:Bay6:Q1.4" | Wait-HPOVTaskComplete
 
-    Write-Output "Adding ImageStreamer Uplink Sets" | Timestamp
-    $ImageStreamerDeploymentNetworkObject = Get-HPOVNetwork -Name "Deployment" -ErrorAction Stop
-    Get-HPOVLogicalInterconnectGroup -Name "LIG-FlexFabric" -ErrorAction Stop | New-HPOVUplinkSet -Name "US-Image Streamer" -Type ImageStreamer -Networks $ImageStreamerDeploymentNetworkObject -UplinkPorts "Enclosure1:Bay3:Q5.1", "Enclosure1:Bay3:Q6.1", "Enclosure2:Bay6:Q5.1", "Enclosure2:Bay6:Q6.1" | Wait-HPOVTaskComplete
+    # Write-Output "Adding ImageStreamer Uplink Sets" | Timestamp
+    # $ImageStreamerDeploymentNetworkObject = Get-HPOVNetwork -Name "Deployment" -ErrorAction Stop
+    # Get-HPOVLogicalInterconnectGroup -Name "LIG-FlexFabric" -ErrorAction Stop | New-HPOVUplinkSet -Name "US-Image Streamer" -Type ImageStreamer -Networks $ImageStreamerDeploymentNetworkObject -UplinkPorts "Enclosure1:Bay3:Q5.1", "Enclosure1:Bay3:Q6.1", "Enclosure2:Bay6:Q5.1", "Enclosure2:Bay6:Q6.1" | Wait-HPOVTaskComplete
 
     Write-Output "All Uplink Sets Configured" | Timestamp
 }
@@ -209,7 +209,7 @@ function Create_Enclosure_Group {
     $3FrameVCLIG = Get-HPOVLogicalInterconnectGroup -Name LIG-FlexFabric
     $SasLIG = Get-HPOVLogicalInterconnectGroup -Name LIG-SAS
     $FcLIG = Get-HPOVLogicalInterconnectGroup -Name LIG-FC
-    New-HPOVEnclosureGroup -name "EG-Synergy-Local" -LogicalInterconnectGroupMapping @{Frame1 = $3FrameVCLIG, $SasLIG, $FcLIG; Frame2 = $3FrameVCLIG, $SasLIG, $FcLIG; Frame3 = $3FrameVCLIG, $SasLIG, $FcLIG } -EnclosureCount 3 -IPv4AddressType External -DeploymentNetworkType Internal
+    New-HPOVEnclosureGroup -name "EG-Synergy-Local" -LogicalInterconnectGroupMapping @{Frame1 = $3FrameVCLIG, $SasLIG, $FcLIG; Frame2 = $3FrameVCLIG, $SasLIG, $FcLIG; Frame3 = $3FrameVCLIG, $SasLIG, $FcLIG } -EnclosureCount 3 -IPv4AddressType External # -DeploymentNetworkType Internal
 
     Write-Output "Enclosure Group Created" | Timestamp
 }
@@ -679,7 +679,7 @@ Configure_SAN_Managers
 Configure_Networks
 Add_Storage
 Add_Users
-Create_OS_Deployment_Server
+# Create_OS_Deployment_Server
 Create_Logical_Interconnect_Groups
 Create_Uplink_Sets
 Create_Enclosure_Group

--- a/Populate_HPE_Synergy.ps1
+++ b/Populate_HPE_Synergy.ps1
@@ -731,3 +731,5 @@ Create_Enclosure_Group_Remote
 Create_Logical_Enclosure_Remote
 
 Write-Output "HPE Synergy Appliance Configuration Complete" | Timestamp
+
+Disconnect-HPOVMgmt

--- a/Populate_HPE_Synergy.ps1
+++ b/Populate_HPE_Synergy.ps1
@@ -3,7 +3,7 @@
 #
 # - Example script for configuring the HPE Synergy Appliance
 #
-#   VERSION 5.0
+#   VERSION 5.20
 #
 #   AUTHORS
 #   Dave Olker - HPE Storage and Big Data

--- a/Populate_HPE_Synergy.ps1
+++ b/Populate_HPE_Synergy.ps1
@@ -31,17 +31,16 @@ THE SOFTWARE.
 #>
 
 # ------------------ Parameters
-Param ( [String]$OVApplianceIP                  = "192.168.62.128",
-        [String]$OVAdminName                    = "Administrator",
-        [String]$OVAuthDomain                   = "Local",
-        [String]$OneViewModule                  = "HPOneView.500"
+Param ( [String]$OVApplianceIP = "192.168.62.128",
+    [String]$OVAdminName = "Administrator",
+    [String]$OVAuthDomain = "Local",
+    [String]$OneViewModule = "HPOneView.520"
 )
 
 
-function Add_Remote_Enclosures
-{
+function Add_Remote_Enclosures {
     Write-Output "Adding Remote Enclosures" | Timestamp
-    Send-HPOVRequest -uri "/rest/enclosures" -method POST -body @{'hostname' = 'fe80::2:0:9:7%eth2'} | Wait-HPOVTaskComplete
+    Send-HPOVRequest -uri "/rest/enclosures" -method POST -body @{'hostname' = 'fe80::2:0:9:7%eth2' } | Wait-HPOVTaskComplete
     Write-Output "Remote Enclosures Added" | Timestamp
     #
     # Sleep for 10 seconds to allow remote enclosures to quiesce
@@ -50,8 +49,7 @@ function Add_Remote_Enclosures
 }
 
 
-function Configure_Address_Pools
-{
+function Configure_Address_Pools {
     Write-Output "Configuring Address Pools for MAC, WWN, and Serial Numbers" | Timestamp
     New-HPOVAddressPoolRange -PoolType vmac -RangeType Generated
     New-HPOVAddressPoolRange -PoolType vwwn -RangeType Generated
@@ -60,8 +58,7 @@ function Configure_Address_Pools
 }
 
 
-function Configure_SAN_Managers
-{
+function Configure_SAN_Managers {
     Write-Output "Configuring SAN Managers" | Timestamp
     Add-HPOVSanManager -Hostname 172.18.20.1 -SnmpUserName dcs-SHA-AES128 -SnmpAuthLevel AuthAndPriv -SnmpAuthPassword dcsdcsdcs -SnmpAuthProtocol sha -SnmpPrivPassword dcsdcsdcs -SnmpPrivProtocol aes-128 -Type Cisco -Port 161 | Wait-HPOVTaskComplete
     Add-HPOVSanManager -Hostname 172.18.20.2 -SnmpUserName dcs-SHA-AES128 -SnmpAuthLevel AuthAndPriv -SnmpAuthPassword dcsdcsdcs -SnmpAuthProtocol sha -SnmpPrivPassword dcsdcsdcs -SnmpPrivProtocol aes-128 -Type Cisco -Port 161 | Wait-HPOVTaskComplete
@@ -69,8 +66,7 @@ function Configure_SAN_Managers
 }
 
 
-function Configure_Networks
-{
+function Configure_Networks {
     Write-Output "Adding IPv4 Subnets" | Timestamp
     New-HPOVAddressPoolSubnet -Domain "mgmt.lan" -Gateway $prod_gateway -NetworkId $prod_subnet -SubnetMask $prod_mask
     New-HPOVAddressPoolSubnet -Domain "deployment.lan" -Gateway $deploy_gateway -NetworkId $deploy_subnet -SubnetMask $deploy_mask
@@ -109,15 +105,14 @@ function Configure_Networks
 }
 
 
-function Add_Storage
-{
+function Add_Storage {
     Write-Output "Adding 3PAR Storage Systems" | Timestamp
     Add-HPOVStorageSystem -Hostname 172.18.11.11 -Password dcs -Username dcs -Domain TestDomain | Wait-HPOVTaskComplete
     Add-HPOVStorageSystem -Hostname 172.18.11.12 -Password dcs -Username dcs -Domain TestDomain | Wait-HPOVTaskComplete
 
     Write-Output "Adding 3PAR Storage Pools" | Timestamp
     $SPNames = @("CPG-SSD", "CPG-SSD-AO", "CPG_FC-AO", "FST_CPG1", "FST_CPG2")
-    for ($i=0; $i -lt $SPNames.Length; $i++) {
+    for ($i = 0; $i -lt $SPNames.Length; $i++) {
         Get-HPOVStoragePool -Name $SPNames[$i] -ErrorAction Stop | Set-HPOVStoragePool -Managed $true | Wait-HPOVTaskComplete
     }
     
@@ -149,8 +144,7 @@ function Add_Storage
 }
 
 
-function Rename_Enclosures
-{
+function Rename_Enclosures {
     Write-Output "Renaming Enclosures" | Timestamp
     $Enc = Get-HPOVEnclosure -Name 0000A66101 -ErrorAction SilentlyContinue
     Set-HPOVEnclosure -Name Synergy-Encl-1 -Enclosure $Enc | Wait-HPOVTaskComplete
@@ -171,8 +165,7 @@ function Rename_Enclosures
 }
 
 
-function Create_Uplink_Sets
-{
+function Create_Uplink_Sets {
     Write-Output "Adding Fibre Channel and FCoE Uplink Sets" | Timestamp
     $LIGFlex = Get-HPOVLogicalInterconnectGroup -Name "LIG-FlexFabric"
     $SAN_A_FC = Get-HPOVNetwork -Name "SAN A FC"
@@ -193,48 +186,45 @@ function Create_Uplink_Sets
     Write-Output "Adding FlexFabric Uplink Sets" | Timestamp
     $LIGFlex = Get-HPOVLogicalInterconnectGroup -Name "LIG-FlexFabric"
     $ESX_Mgmt = Get-HPOVNetwork -Name "ESX Mgmt"
-    New-HPOVUplinkSet -Resource $LIGFlex -Name "US-ESX-Mgmt" -Type Ethernet -Networks $ESX_Mgmt -UplinkPorts "Enclosure1:Bay3:Q1.2","Enclosure2:Bay6:Q1.2" | Wait-HPOVTaskComplete
+    New-HPOVUplinkSet -Resource $LIGFlex -Name "US-ESX-Mgmt" -Type Ethernet -Networks $ESX_Mgmt -UplinkPorts "Enclosure1:Bay3:Q1.2", "Enclosure2:Bay6:Q1.2" | Wait-HPOVTaskComplete
 
     $LIGFlex = Get-HPOVLogicalInterconnectGroup -Name "LIG-FlexFabric"
     $ESX_vMotion = Get-HPOVNetwork -Name "ESX vMotion"
-    New-HPOVUplinkSet -Resource $LIGFlex -Name "US-ESX-vMotion" -Type Ethernet -Networks $ESX_vMotion -UplinkPorts "Enclosure1:Bay3:Q1.3","Enclosure2:Bay6:Q1.3" | Wait-HPOVTaskComplete
+    New-HPOVUplinkSet -Resource $LIGFlex -Name "US-ESX-vMotion" -Type Ethernet -Networks $ESX_vMotion -UplinkPorts "Enclosure1:Bay3:Q1.3", "Enclosure2:Bay6:Q1.3" | Wait-HPOVTaskComplete
 
     $LIGFlex = Get-HPOVLogicalInterconnectGroup -Name "LIG-FlexFabric"
     $Prod_Nets = Get-HPOVNetwork -Name "Prod*"
-    New-HPOVUplinkSet -Resource $LIGFlex -Name "US-Prod" -Type Ethernet -Networks $Prod_Nets -UplinkPorts "Enclosure1:Bay3:Q1.4","Enclosure2:Bay6:Q1.4" | Wait-HPOVTaskComplete
+    New-HPOVUplinkSet -Resource $LIGFlex -Name "US-Prod" -Type Ethernet -Networks $Prod_Nets -UplinkPorts "Enclosure1:Bay3:Q1.4", "Enclosure2:Bay6:Q1.4" | Wait-HPOVTaskComplete
 
     Write-Output "Adding ImageStreamer Uplink Sets" | Timestamp
     $ImageStreamerDeploymentNetworkObject = Get-HPOVNetwork -Name "Deployment" -ErrorAction Stop
-    Get-HPOVLogicalInterconnectGroup -Name "LIG-FlexFabric" -ErrorAction Stop | New-HPOVUplinkSet -Name "US-Image Streamer" -Type ImageStreamer -Networks $ImageStreamerDeploymentNetworkObject -UplinkPorts "Enclosure1:Bay3:Q5.1","Enclosure1:Bay3:Q6.1","Enclosure2:Bay6:Q5.1","Enclosure2:Bay6:Q6.1" | Wait-HPOVTaskComplete
+    Get-HPOVLogicalInterconnectGroup -Name "LIG-FlexFabric" -ErrorAction Stop | New-HPOVUplinkSet -Name "US-Image Streamer" -Type ImageStreamer -Networks $ImageStreamerDeploymentNetworkObject -UplinkPorts "Enclosure1:Bay3:Q5.1", "Enclosure1:Bay3:Q6.1", "Enclosure2:Bay6:Q5.1", "Enclosure2:Bay6:Q6.1" | Wait-HPOVTaskComplete
 
     Write-Output "All Uplink Sets Configured" | Timestamp
 }
 
 
-function Create_Enclosure_Group
-{
+function Create_Enclosure_Group {
     $3FrameVCLIG = Get-HPOVLogicalInterconnectGroup -Name LIG-FlexFabric
     $SasLIG = Get-HPOVLogicalInterconnectGroup -Name LIG-SAS
     $FcLIG = Get-HPOVLogicalInterconnectGroup -Name LIG-FC
-    New-HPOVEnclosureGroup -name "EG-Synergy-Local" -LogicalInterconnectGroupMapping @{Frame1 = $3FrameVCLIG,$SasLIG,$FcLIG; Frame2 = $3FrameVCLIG,$SasLIG,$FcLIG; Frame3 = $3FrameVCLIG,$SasLIG,$FcLIG} -EnclosureCount 3 -IPv4AddressType External -DeploymentNetworkType Internal
+    New-HPOVEnclosureGroup -name "EG-Synergy-Local" -LogicalInterconnectGroupMapping @{Frame1 = $3FrameVCLIG, $SasLIG, $FcLIG; Frame2 = $3FrameVCLIG, $SasLIG, $FcLIG; Frame3 = $3FrameVCLIG, $SasLIG, $FcLIG } -EnclosureCount 3 -IPv4AddressType External -DeploymentNetworkType Internal
 
     Write-Output "Enclosure Group Created" | Timestamp
 }
 
 
-function Create_Enclosure_Group_Remote
-{
+function Create_Enclosure_Group_Remote {
     $2FrameVCLIG_1 = Get-HPOVLogicalInterconnectGroup -Name LIG-FlexFabric-Remote-1
     $2FrameVCLIG_2 = Get-HPOVLogicalInterconnectGroup -Name LIG-FlexFabric-Remote-2
     $FcLIG = Get-HPOVLogicalInterconnectGroup -Name LIG-FC-Remote
-    New-HPOVEnclosureGroup -name "EG-Synergy-Remote" -LogicalInterconnectGroupMapping @{Frame1 = $FcLIG,$2FrameVCLIG_1,$2FrameVCLIG_2; Frame2 = $FcLIG,$2FrameVCLIG_1,$2FrameVCLIG_2} -EnclosureCount 2
+    New-HPOVEnclosureGroup -name "EG-Synergy-Remote" -LogicalInterconnectGroupMapping @{Frame1 = $FcLIG, $2FrameVCLIG_1, $2FrameVCLIG_2; Frame2 = $FcLIG, $2FrameVCLIG_1, $2FrameVCLIG_2 } -EnclosureCount 2
 
     Write-Output "Enclosure Group Created" | Timestamp
 }
 
 
-function Create_Logical_Enclosure
-{
+function Create_Logical_Enclosure {
     Write-Output "Creating Local Logical Enclosure" | Timestamp
     $EG = Get-HPOVEnclosureGroup -Name EG-Synergy-Local
     $Encl = Get-HPOVEnclosure -Name Synergy-Encl-1
@@ -243,8 +233,7 @@ function Create_Logical_Enclosure
 }
 
 
-function Create_Logical_Enclosure_Remote
-{
+function Create_Logical_Enclosure_Remote {
     Write-Output "Creating Remote Logical Enclosure" | Timestamp
     $EG = Get-HPOVEnclosureGroup -Name EG-Synergy-Remote
     $Encl = Get-HPOVEnclosure -Name Synergy-Encl-4
@@ -253,28 +242,25 @@ function Create_Logical_Enclosure_Remote
 }
 
 
-function Create_Logical_Interconnect_Groups
-{
+function Create_Logical_Interconnect_Groups {
     Write-Output "Creating Local Logical Interconnect Groups" | Timestamp
-    New-HPOVLogicalInterconnectGroup -Name "LIG-SAS" -FrameCount 1 -InterconnectBaySet 1 -FabricModuleType "SAS" -Bays @{Frame1 = @{Bay1 = "SE12SAS" ; Bay4 = "SE12SAS"}}
-    New-HPOVLogicalInterconnectGroup -Name "LIG-FC" -FrameCount 1 -InterconnectBaySet 2 -FabricModuleType "SEVCFC" -Bays @{Frame1 = @{Bay2 = "SEVC16GbFC" ; Bay5 = "SEVC16GbFC"}}
-    New-HPOVLogicalInterconnectGroup -Name "LIG-FlexFabric" -FrameCount 3 -InterconnectBaySet 3 -FabricModuleType "SEVC40F8" -Bays @{Frame1 = @{Bay3 = "SEVC40f8" ; Bay6 = "SE20ILM"};Frame2 = @{Bay3 = "SE20ILM"; Bay6 = "SEVC40f8" };Frame3 = @{Bay3 = "SE20ILM"; Bay6 = "SE20ILM"}} -FabricRedundancy "HighlyAvailable"
+    New-HPOVLogicalInterconnectGroup -Name "LIG-SAS" -FrameCount 1 -InterconnectBaySet 1 -FabricModuleType "SAS" -Bays @{Frame1 = @{Bay1 = "SE12SAS" ; Bay4 = "SE12SAS" } }
+    New-HPOVLogicalInterconnectGroup -Name "LIG-FC" -FrameCount 1 -InterconnectBaySet 2 -FabricModuleType "SEVCFC" -Bays @{Frame1 = @{Bay2 = "SEVC16GbFC" ; Bay5 = "SEVC16GbFC" } }
+    New-HPOVLogicalInterconnectGroup -Name "LIG-FlexFabric" -FrameCount 3 -InterconnectBaySet 3 -FabricModuleType "SEVC40F8" -Bays @{Frame1 = @{Bay3 = "SEVC40f8" ; Bay6 = "SE20ILM" }; Frame2 = @{Bay3 = "SE20ILM"; Bay6 = "SEVC40f8" }; Frame3 = @{Bay3 = "SE20ILM"; Bay6 = "SE20ILM" } } -FabricRedundancy "HighlyAvailable"
     Write-Output "Logical Interconnect Groups Created" | Timestamp
 }
 
 
-function Create_Logical_Interconnect_Groups_Remote
-{
+function Create_Logical_Interconnect_Groups_Remote {
     Write-Output "Creating Remote Logical Interconnect Groups" | Timestamp
-    New-HPOVLogicalInterconnectGroup -Name "LIG-FC-Remote" -FrameCount 1 -InterconnectBaySet 1 -FabricModuleType "SEVCFC" -Bays @{Frame1 = @{Bay1 = "SEVC16GbFC" ; Bay4 = "SEVC16GbFC"}}
-    New-HPOVLogicalInterconnectGroup -Name "LIG-FlexFabric-Remote-1" -FrameCount 2 -InterconnectBaySet 2 -FabricModuleType "SEVC40F8" -Bays @{Frame1 = @{Bay2 = "SEVC40f8" ; Bay5 = "SE20ILM"};Frame2 = @{Bay2 = "SE20ILM"; Bay5 = "SEVC40F8" }} -FabricRedundancy "HighlyAvailable"
-    New-HPOVLogicalInterconnectGroup -Name "LIG-FlexFabric-Remote-2" -FrameCount 2 -InterconnectBaySet 3 -FabricModuleType "SEVC40F8" -Bays @{Frame1 = @{Bay3 = "SEVC40f8" ; Bay6 = "SE20ILM"};Frame2 = @{Bay3 = "SE20ILM"; Bay6 = "SEVC40F8" }} -FabricRedundancy "HighlyAvailable"
+    New-HPOVLogicalInterconnectGroup -Name "LIG-FC-Remote" -FrameCount 1 -InterconnectBaySet 1 -FabricModuleType "SEVCFC" -Bays @{Frame1 = @{Bay1 = "SEVC16GbFC" ; Bay4 = "SEVC16GbFC" } }
+    New-HPOVLogicalInterconnectGroup -Name "LIG-FlexFabric-Remote-1" -FrameCount 2 -InterconnectBaySet 2 -FabricModuleType "SEVC40F8" -Bays @{Frame1 = @{Bay2 = "SEVC40f8" ; Bay5 = "SE20ILM" }; Frame2 = @{Bay2 = "SE20ILM"; Bay5 = "SEVC40F8" } } -FabricRedundancy "HighlyAvailable"
+    New-HPOVLogicalInterconnectGroup -Name "LIG-FlexFabric-Remote-2" -FrameCount 2 -InterconnectBaySet 3 -FabricModuleType "SEVC40F8" -Bays @{Frame1 = @{Bay3 = "SEVC40f8" ; Bay6 = "SE20ILM" }; Frame2 = @{Bay3 = "SE20ILM"; Bay6 = "SEVC40F8" } } -FabricRedundancy "HighlyAvailable"
     Write-Output "Logical Interconnect Groups Created" | Timestamp
 }
 
 
-function Add_Licenses
-{
+function Add_Licenses {
     Write-Output "Adding OneView and Synergy FC Licenses" | Timestamp
 
     $License_File = Read-Host -Prompt "Optional: Enter Filename Containing OneView and Synergy FC Licenses"
@@ -286,8 +272,7 @@ function Add_Licenses
 }
 
 
-function Add_Firmware_Bundle
-{
+function Add_Firmware_Bundle {
     Write-Output "Adding Firmware Bundles" | Timestamp
     $firmware_bundle = Read-Host "Optional: Specify location of Service Pack for ProLiant ISO file"
     if ($firmware_bundle) {
@@ -303,8 +288,7 @@ function Add_Firmware_Bundle
 }
 
 
-function Create_OS_Deployment_Server
-{
+function Create_OS_Deployment_Server {
     Write-Output "Configuring OS Deployment Servers" | Timestamp
     $ManagementNetwork = Get-HPOVNetwork -Type Ethernet -Name "Mgmt"
     Get-HPOVImageStreamerAppliance | Select-Object -First 1 | New-HPOVOSDeploymentServer -Name "LE1 Image Streamer" -ManagementNetwork $ManagementNetwork -Description "Image Streamer for Logical Enclosure 1" | Wait-HPOVTaskComplete
@@ -312,17 +296,16 @@ function Create_OS_Deployment_Server
 }
 
 
-function Create_Server_Profile_Template_SY480_Gen9_RHEL_Local_Boot
-{
+function Create_Server_Profile_Template_SY480_Gen9_RHEL_Local_Boot {
     Write-Output "Creating SY480 Gen9 with Local Boot for RHEL Server Profile Template" | Timestamp
 
-    $SHT               = Get-HPOVServerHardwareTypes -Name "SY 480 Gen9 1" -ErrorAction Stop
-    $EnclGroup         = Get-HPOVEnclosureGroup -Name "EG-Synergy-Local" -ErrorAction Stop
-    $Eth1              = Get-HPOVNetworkSet -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 1 -Name 'Prod-NetworkSet-1' -PortId "Mezz 3:1-c"
-    $Eth2              = Get-HPOVNetworkset -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 2 -Name 'Prod-NetworkSet-2' -PortId "Mezz 3:2-c"
-    $Deploy1           = Get-HPOVNetwork -Name "Deployment" | New-HPOVServerProfileConnection -ConnectionID 3 -Name 'Deployment Network A' -PortId "Mezz 3:1-a" #-Bootable -Priority Primary
-    $Deploy2           = Get-HPOVNetwork -Name "Deployment" | New-HPOVServerProfileConnection -ConnectionID 4 -Name 'Deployment Network B' -PortId "Mezz 3:2-a" #-Bootable -Priority Secondary
-    $LogicalDisk       = New-HPOVServerProfileLogicalDisk -Name "SAS RAID1 SSD" -RAID RAID1 -NumberofDrives 2 -DriveType SASSSD -Bootable $True
+    $SHT = Get-HPOVServerHardwareTypes -Name "SY 480 Gen9 1" -ErrorAction Stop
+    $EnclGroup = Get-HPOVEnclosureGroup -Name "EG-Synergy-Local" -ErrorAction Stop
+    $Eth1 = Get-HPOVNetworkSet -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 1 -Name 'Prod-NetworkSet-1' -PortId "Mezz 3:1-c"
+    $Eth2 = Get-HPOVNetworkset -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 2 -Name 'Prod-NetworkSet-2' -PortId "Mezz 3:2-c"
+    $Deploy1 = Get-HPOVNetwork -Name "Deployment" | New-HPOVServerProfileConnection -ConnectionID 3 -Name 'Deployment Network A' -PortId "Mezz 3:1-a" #-Bootable -Priority Primary
+    $Deploy2 = Get-HPOVNetwork -Name "Deployment" | New-HPOVServerProfileConnection -ConnectionID 4 -Name 'Deployment Network B' -PortId "Mezz 3:2-a" #-Bootable -Priority Secondary
+    $LogicalDisk = New-HPOVServerProfileLogicalDisk -Name "SAS RAID1 SSD" -RAID RAID1 -NumberofDrives 2 -DriveType SASSSD -Bootable $True
     $StorageController = New-HPOVServerProfileLogicalDiskController -ControllerID Embedded -Mode RAID -Initialize -LogicalDisk $LogicalDisk
 
     $params = @{
@@ -351,13 +334,12 @@ function Create_Server_Profile_Template_SY480_Gen9_RHEL_Local_Boot
 }
 
 
-function Create_Server_Profile_SY480_Gen9_RHEL_Local_Boot
-{
+function Create_Server_Profile_SY480_Gen9_RHEL_Local_Boot {
     Write-Output "Creating SY480 Gen9 Local Boot for RHEL Server Profile" | Timestamp
 
-    $SHT            = Get-HPOVServerHardwareTypes -Name "SY 480 Gen9 1" -ErrorAction Stop
-    $Template       = Get-HPOVServerProfileTemplate -Name "HPE Synergy 480 Gen9 with Local Boot for RHEL Template" -ErrorAction Stop
-    $Server         = Get-HPOVServer -ServerHardwareType $SHT -NoProfile -ErrorAction Stop | Select-Object -First 1
+    $SHT = Get-HPOVServerHardwareTypes -Name "SY 480 Gen9 1" -ErrorAction Stop
+    $Template = Get-HPOVServerProfileTemplate -Name "HPE Synergy 480 Gen9 with Local Boot for RHEL Template" -ErrorAction Stop
+    $Server = Get-HPOVServer -ServerHardwareType $SHT -NoProfile -ErrorAction Stop | Select-Object -First 1
 
     $params = @{
         AssignmentType        = "Server";
@@ -372,18 +354,17 @@ function Create_Server_Profile_SY480_Gen9_RHEL_Local_Boot
 }
 
 
-function Create_Server_Profile_Template_SY660_Gen9_Windows_SAN_Storage
-{
+function Create_Server_Profile_Template_SY660_Gen9_Windows_SAN_Storage {
     Write-Output "Creating SY660 Gen9 with Local Boot and SAN Storage for Windows Server Profile Template" | Timestamp
 
-    $SHT               = Get-HPOVServerHardwareTypes -Name "SY 660 Gen9 1" -ErrorAction Stop
-    $EnclGroup         = Get-HPOVEnclosureGroup -Name "EG-Synergy-Local" -ErrorAction Stop
-    $Eth1              = Get-HPOVNetworkSet -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 1 -Name 'Prod-NetworkSet-1' -PortId "Mezz 3:1-c"
-    $Eth2              = Get-HPOVNetworkset -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 2 -Name 'Prod-NetworkSet-2' -PortId "Mezz 3:2-c"
-    $FC1               = Get-HPOVNetwork -Name 'SAN A FC' | New-HPOVServerProfileConnection -connectionId 3
-    $FC2               = Get-HPOVNetwork -Name 'SAN B FC' | New-HPOVServerProfileConnection -connectionId 4
-    $LogicalDisk       = New-HPOVServerProfileLogicalDisk -Name "SAS RAID5 SSD" -RAID RAID5 -NumberofDrives 3 -DriveType SASSSD -Bootable $True
-    $SANVol            = Get-HPOVStorageVolume -Name "Shared-Volume-2" | New-HPOVServerProfileAttachVolume -VolumeID 1
+    $SHT = Get-HPOVServerHardwareTypes -Name "SY 660 Gen9 1" -ErrorAction Stop
+    $EnclGroup = Get-HPOVEnclosureGroup -Name "EG-Synergy-Local" -ErrorAction Stop
+    $Eth1 = Get-HPOVNetworkSet -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 1 -Name 'Prod-NetworkSet-1' -PortId "Mezz 3:1-c"
+    $Eth2 = Get-HPOVNetworkset -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 2 -Name 'Prod-NetworkSet-2' -PortId "Mezz 3:2-c"
+    $FC1 = Get-HPOVNetwork -Name 'SAN A FC' | New-HPOVServerProfileConnection -connectionId 3
+    $FC2 = Get-HPOVNetwork -Name 'SAN B FC' | New-HPOVServerProfileConnection -connectionId 4
+    $LogicalDisk = New-HPOVServerProfileLogicalDisk -Name "SAS RAID5 SSD" -RAID RAID5 -NumberofDrives 3 -DriveType SASSSD -Bootable $True
+    $SANVol = Get-HPOVStorageVolume -Name "Shared-Volume-2" | New-HPOVServerProfileAttachVolume -VolumeID 1
     $StorageController = New-HPOVServerProfileLogicalDiskController -ControllerID Embedded -Mode RAID -Initialize -LogicalDisk $LogicalDisk
 
     $params = @{
@@ -412,13 +393,12 @@ function Create_Server_Profile_Template_SY660_Gen9_Windows_SAN_Storage
 }
 
 
-function Create_Server_Profile_SY660_Gen9_Windows_SAN_Storage
-{
+function Create_Server_Profile_SY660_Gen9_Windows_SAN_Storage {
     Write-Output "Creating SY660 Gen9 with Local Boot and SAN Storage for Windows Server Profile" | Timestamp
 
-    $SHT            = Get-HPOVServerHardwareTypes -Name "SY 660 Gen9 1" -ErrorAction Stop
-    $Template       = Get-HPOVServerProfileTemplate -Name "HPE Synergy 660 Gen9 with Local Boot and SAN Storage for Windows Template" -ErrorAction Stop
-    $Server         = Get-HPOVServer -ServerHardwareType $SHT -NoProfile -ErrorAction Stop | Select-Object -First 1
+    $SHT = Get-HPOVServerHardwareTypes -Name "SY 660 Gen9 1" -ErrorAction Stop
+    $Template = Get-HPOVServerProfileTemplate -Name "HPE Synergy 660 Gen9 with Local Boot and SAN Storage for Windows Template" -ErrorAction Stop
+    $Server = Get-HPOVServer -ServerHardwareType $SHT -NoProfile -ErrorAction Stop | Select-Object -First 1
 
     $params = @{
         AssignmentType        = "Server";
@@ -433,18 +413,17 @@ function Create_Server_Profile_SY660_Gen9_Windows_SAN_Storage
 }
 
 
-function Create_Server_Profile_Template_SY480_Gen9_ESX_SAN_Boot
-{
+function Create_Server_Profile_Template_SY480_Gen9_ESX_SAN_Boot {
     Write-Output "Creating SY480 Gen9 with SAN Boot for ESX Server Profile Template" | Timestamp
 
-    $SHT               = Get-HPOVServerHardwareTypes -Name "SY 480 Gen9 2" -ErrorAction Stop
-    $EnclGroup         = Get-HPOVEnclosureGroup -Name "EG-Synergy-Local" -ErrorAction Stop
-    $Eth1              = Get-HPOVNetworkSet -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 1 -Name 'Prod-NetworkSet-1' -PortId "Mezz 3:1-c"
-    $Eth2              = Get-HPOVNetworkset -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 2 -Name 'Prod-NetworkSet-2' -PortId "Mezz 3:2-c"
-    $FC1               = Get-HPOVNetwork -Name 'SAN A FC' | New-HPOVServerProfileConnection -ConnectionID 3 -Bootable -Priority Primary -BootVolumeSource ManagedVolume -ConnectionType FibreChannel
-    $FC2               = Get-HPOVNetwork -Name 'SAN B FC' | New-HPOVServerProfileConnection -ConnectionID 4 -Bootable -Priority Secondary -BootVolumeSource ManagedVolume -ConnectionType FibreChannel
-    $StoragePool       = Get-HPOVStoragePool -Name FST_CPG1 -StorageSystem ThreePAR-1 -ErrorAction Stop
-    $SANVol            = New-HPOVServerProfileAttachVolume -Name BootVol -StoragePool $StoragePool -BootVolume -Capacity 100 -LunIdType Auto
+    $SHT = Get-HPOVServerHardwareTypes -Name "SY 480 Gen9 2" -ErrorAction Stop
+    $EnclGroup = Get-HPOVEnclosureGroup -Name "EG-Synergy-Local" -ErrorAction Stop
+    $Eth1 = Get-HPOVNetworkSet -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 1 -Name 'Prod-NetworkSet-1' -PortId "Mezz 3:1-c"
+    $Eth2 = Get-HPOVNetworkset -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 2 -Name 'Prod-NetworkSet-2' -PortId "Mezz 3:2-c"
+    $FC1 = Get-HPOVNetwork -Name 'SAN A FC' | New-HPOVServerProfileConnection -ConnectionID 3 -Bootable -Priority Primary -BootVolumeSource ManagedVolume -ConnectionType FibreChannel
+    $FC2 = Get-HPOVNetwork -Name 'SAN B FC' | New-HPOVServerProfileConnection -ConnectionID 4 -Bootable -Priority Secondary -BootVolumeSource ManagedVolume -ConnectionType FibreChannel
+    $StoragePool = Get-HPOVStoragePool -Name FST_CPG1 -StorageSystem ThreePAR-1 -ErrorAction Stop
+    $SANVol = New-HPOVServerProfileAttachVolume -Name BootVol -StoragePool $StoragePool -BootVolume -Capacity 100 -LunIdType Auto
 
     $params = @{
         Affinity                 = "Bay";
@@ -471,13 +450,12 @@ function Create_Server_Profile_Template_SY480_Gen9_ESX_SAN_Boot
 }
 
 
-function Create_Server_Profile_SY480_Gen9_ESX_SAN_Boot
-{
+function Create_Server_Profile_SY480_Gen9_ESX_SAN_Boot {
     Write-Output "Creating SY480 Gen9 SAN Boot for ESX Server Profile" | Timestamp
 
-    $SHT            = Get-HPOVServerHardwareTypes -Name "SY 480 Gen9 2" -ErrorAction Stop
-    $Template       = Get-HPOVServerProfileTemplate -Name "HPE Synergy 480 Gen9 with SAN Boot for ESX Template" -ErrorAction Stop
-    $Server         = Get-HPOVServer -ServerHardwareType $SHT -NoProfile -ErrorAction Stop | Select-Object -First 1
+    $SHT = Get-HPOVServerHardwareTypes -Name "SY 480 Gen9 2" -ErrorAction Stop
+    $Template = Get-HPOVServerProfileTemplate -Name "HPE Synergy 480 Gen9 with SAN Boot for ESX Template" -ErrorAction Stop
+    $Server = Get-HPOVServer -ServerHardwareType $SHT -NoProfile -ErrorAction Stop | Select-Object -First 1
 
     $params = @{
         AssignmentType        = "Server";
@@ -492,18 +470,17 @@ function Create_Server_Profile_SY480_Gen9_ESX_SAN_Boot
 }
 
 
-function Create_Server_Profile_Template_SY480_Gen10_ESX_SAN_Boot
-{
+function Create_Server_Profile_Template_SY480_Gen10_ESX_SAN_Boot {
     Write-Output "Creating SY480 Gen10 with SAN Boot for ESX Server Profile Template" | Timestamp
 
-    $SHT               = Get-HPOVServerHardwareTypes -Name "SY 480 Gen10 1" -ErrorAction Stop
-    $EnclGroup         = Get-HPOVEnclosureGroup -Name "EG-Synergy-Local" -ErrorAction Stop
-    $Eth1              = Get-HPOVNetworkSet -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 1 -Name 'Prod-NetworkSet-1' -PortId "Mezz 3:1-c"
-    $Eth2              = Get-HPOVNetworkset -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 2 -Name 'Prod-NetworkSet-2' -PortId "Mezz 3:2-c"
-    $FC1               = Get-HPOVNetwork -Name 'SAN A FC' | New-HPOVServerProfileConnection -ConnectionID 3 -Bootable -Priority Primary -BootVolumeSource ManagedVolume -ConnectionType FibreChannel
-    $FC2               = Get-HPOVNetwork -Name 'SAN B FC' | New-HPOVServerProfileConnection -ConnectionID 4 -Bootable -Priority Secondary -BootVolumeSource ManagedVolume -ConnectionType FibreChannel
-    $StoragePool       = Get-HPOVStoragePool -Name FST_CPG1 -StorageSystem ThreePAR-2 -ErrorAction Stop
-    $SANVol            = New-HPOVServerProfileAttachVolume -Name BootVol-Gen10 -StoragePool $StoragePool -BootVolume -Capacity 100 -LunIdType Auto
+    $SHT = Get-HPOVServerHardwareTypes -Name "SY 480 Gen10 1" -ErrorAction Stop
+    $EnclGroup = Get-HPOVEnclosureGroup -Name "EG-Synergy-Local" -ErrorAction Stop
+    $Eth1 = Get-HPOVNetworkSet -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 1 -Name 'Prod-NetworkSet-1' -PortId "Mezz 3:1-c"
+    $Eth2 = Get-HPOVNetworkset -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 2 -Name 'Prod-NetworkSet-2' -PortId "Mezz 3:2-c"
+    $FC1 = Get-HPOVNetwork -Name 'SAN A FC' | New-HPOVServerProfileConnection -ConnectionID 3 -Bootable -Priority Primary -BootVolumeSource ManagedVolume -ConnectionType FibreChannel
+    $FC2 = Get-HPOVNetwork -Name 'SAN B FC' | New-HPOVServerProfileConnection -ConnectionID 4 -Bootable -Priority Secondary -BootVolumeSource ManagedVolume -ConnectionType FibreChannel
+    $StoragePool = Get-HPOVStoragePool -Name FST_CPG1 -StorageSystem ThreePAR-2 -ErrorAction Stop
+    $SANVol = New-HPOVServerProfileAttachVolume -Name BootVol-Gen10 -StoragePool $StoragePool -BootVolume -Capacity 100 -LunIdType Auto
 
     #
     # Check if firmware bundles are installed.  If there are, select the last one
@@ -532,7 +509,8 @@ function Create_Server_Profile_Template_SY480_Gen10_ESX_SAN_Boot
             ServerProfileDescription = "Server Profile for HPE Synergy 480 Gen10 Compute Module with SAN Boot for ESX";
             StorageVolume            = $SANVol
         }
-    } else {
+    }
+    else {
         $params = @{
             Affinity                 = "Bay";
             BootMode                 = "BIOS";
@@ -558,13 +536,12 @@ function Create_Server_Profile_Template_SY480_Gen10_ESX_SAN_Boot
 }
 
 
-function Create_Server_Profile_SY480_Gen10_ESX_SAN_Boot
-{
+function Create_Server_Profile_SY480_Gen10_ESX_SAN_Boot {
     Write-Output "Creating SY480 Gen10 SAN Boot for ESX Server Profile" | Timestamp
 
-    $SHT            = Get-HPOVServerHardwareTypes -Name "SY 480 Gen10 1" -ErrorAction Stop
-    $Template       = Get-HPOVServerProfileTemplate -Name "HPE Synergy 480 Gen10 with SAN Boot for ESX Template" -ErrorAction Stop
-    $Server         = Get-HPOVServer -ServerHardwareType $SHT -NoProfile -ErrorAction Stop | Select-Object -First 1
+    $SHT = Get-HPOVServerHardwareTypes -Name "SY 480 Gen10 1" -ErrorAction Stop
+    $Template = Get-HPOVServerProfileTemplate -Name "HPE Synergy 480 Gen10 with SAN Boot for ESX Template" -ErrorAction Stop
+    $Server = Get-HPOVServer -ServerHardwareType $SHT -NoProfile -ErrorAction Stop | Select-Object -First 1
 
     $params = @{
         AssignmentType        = "Server";
@@ -579,8 +556,7 @@ function Create_Server_Profile_SY480_Gen10_ESX_SAN_Boot
 }
 
 
-function PowerOff_All_Servers
-{
+function PowerOff_All_Servers {
     Write-Output "Powering Off All Servers" | Timestamp
 
     $Servers = Get-HPOVServer
@@ -596,8 +572,7 @@ function PowerOff_All_Servers
 }
 
 
-function Add_Users
-{
+function Add_Users {
     Write-Output "Adding New Users" | Timestamp
 
     New-HPOVUser -UserName BackupAdmin -FullName "Backup Administrator" -Password BackupPasswd -Roles "Backup Administrator" -EmailAddress "backup@hpe.com" -OfficePhone "(111) 111-1111" -MobilePhone "(999) 999-9999"
@@ -610,8 +585,7 @@ function Add_Users
 }
 
 
-function Add_Scopes
-{
+function Add_Scopes {
     Write-Output "Adding New Scopes" | Timestamp
 
     New-HPOVScope -Name FinanceScope -Description "Finance Scope of Resources"
@@ -640,42 +614,36 @@ Remove-Module -ErrorAction SilentlyContinue HPOneView.400
 Remove-Module -ErrorAction SilentlyContinue HPOneView.410
 Remove-Module -ErrorAction SilentlyContinue HPOneView.420
 
-if (-not (Get-Module HPOneview.500))
-{
+if (-not (Get-Module HPOneview.500)) {
     Import-Module -Name HPOneView.500
 }
 
-if (-not $ConnectedSessions)
-{
-    $ApplianceIP     = Read-Host -Prompt "Synergy Composer IP Address [$OVApplianceIP]"
-    if ([string]::IsNullOrWhiteSpace($ApplianceIP))
-    {
+if (-not $ConnectedSessions) {
+    $ApplianceIP = Read-Host -Prompt "Synergy Composer IP Address [$OVApplianceIP]"
+    if ([string]::IsNullOrWhiteSpace($ApplianceIP)) {
         $ApplianceIP = $OVApplianceIP
     }
 
-    $AdminName       = Read-Host -Prompt "Administrator Username [$OVAdminName]"
-    if ([string]::IsNullOrWhiteSpace($AdminName))
-    {
-        $AdminName   = $OVAdminName
+    $AdminName = Read-Host -Prompt "Administrator Username [$OVAdminName]"
+    if ([string]::IsNullOrWhiteSpace($AdminName)) {
+        $AdminName = $OVAdminName
     }
 
-    $AdminCred       = Get-Credential -UserName $AdminName -Message "Password required for the user '$AdminName'"
-    if ([string]::IsNullOrWhiteSpace($AdminCred))
-    {
+    $AdminCred = Get-Credential -UserName $AdminName -Message "Password required for the user '$AdminName'"
+    if ([string]::IsNullOrWhiteSpace($AdminCred)) {
         Write-Output "Blank Credential is not permitted.  Exiting."
         Exit
     }
 
     Connect-HPOVMgmt -Hostname $ApplianceIP -Credential $AdminCred -AuthLoginDomain $OVAuthDomain -ErrorAction Stop
 
-    if (-not $ConnectedSessions)
-    {
+    if (-not $ConnectedSessions) {
         Write-Output "Login to Synergy System failed.  Exiting."
         Exit
     }
 }
 
-filter Timestamp {"$(Get-Date -Format G): $_"}
+filter Timestamp { "$(Get-Date -Format G): $_" }
 
 
 ##########################################################################
@@ -690,7 +658,8 @@ if (Test-Path $config_file) {
         $var = $_.Split('=')
         New-Variable -Name $var[0] -Value $var[1] -Scope Global -Force
     }
-} else {
+}
+else {
     Write-Output "Configuration file '$config_file' not found.  Exiting." | Timestamp
     Exit
 }

--- a/Populate_HPE_Synergy.ps1
+++ b/Populate_HPE_Synergy.ps1
@@ -652,7 +652,7 @@ filter Timestamp { "$(Get-Date -Format G): $_" }
 # Process variables in the Populate_HPE_Synergy-Params.txt file.
 #
 ##########################################################################
-New-Variable -Name config_file -Value .\Populate_HPE_Synergy-Params.txt -Scope Global -Force
+New-Variable -Name config_file -Value $PSScriptRoot\Populate_HPE_Synergy-Params.txt -Scope Global -Force
 
 if (Test-Path $config_file) {
     Get-Content $config_file | Where-Object { !$_.StartsWith("#") } | Foreach-Object {

--- a/Populate_HPE_Synergy.ps1
+++ b/Populate_HPE_Synergy.ps1
@@ -318,8 +318,8 @@ function Create_Server_Profile_Template_SY480_Gen9_RHEL_Local_Boot
 
     $SHT               = Get-HPOVServerHardwareTypes -Name "SY 480 Gen9 1" -ErrorAction Stop
     $EnclGroup         = Get-HPOVEnclosureGroup -Name "EG-Synergy-Local" -ErrorAction Stop
-    $Eth1              = Get-HPOVNetwork -Name "Prod_1101" | New-HPOVServerProfileConnection -ConnectionID 1 -Name 'Prod-1101' -PortId "Mezz 3:1-c"
-    $Eth2              = Get-HPOVNetwork -Name "Prod_1102" | New-HPOVServerProfileConnection -ConnectionID 2 -Name 'Prod-1102' -PortId "Mezz 3:2-c"
+    $Eth1              = Get-HPOVNetworkSet -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 1 -Name 'Prod-NetworkSet-1' -PortId "Mezz 3:1-c"
+    $Eth2              = Get-HPOVNetworkset -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 2 -Name 'Prod-NetworkSet-2' -PortId "Mezz 3:2-c"
     $Deploy1           = Get-HPOVNetwork -Name "Deployment" | New-HPOVServerProfileConnection -ConnectionID 3 -Name 'Deployment Network A' -PortId "Mezz 3:1-a" -Bootable -Priority Primary
     $Deploy2           = Get-HPOVNetwork -Name "Deployment" | New-HPOVServerProfileConnection -ConnectionID 4 -Name 'Deployment Network B' -PortId "Mezz 3:2-a" -Bootable -Priority Secondary
     $LogicalDisk       = New-HPOVServerProfileLogicalDisk -Name "SAS RAID1 SSD" -RAID RAID1 -NumberofDrives 2 -DriveType SASSSD -Bootable $True
@@ -378,8 +378,8 @@ function Create_Server_Profile_Template_SY660_Gen9_Windows_SAN_Storage
 
     $SHT               = Get-HPOVServerHardwareTypes -Name "SY 660 Gen9 1" -ErrorAction Stop
     $EnclGroup         = Get-HPOVEnclosureGroup -Name "EG-Synergy-Local" -ErrorAction Stop
-    $Eth1              = Get-HPOVNetwork -Name "Prod_1101" | New-HPOVServerProfileConnection -ConnectionID 1 -Name 'Prod-1101' -PortId "Mezz 3:1-c"
-    $Eth2              = Get-HPOVNetwork -Name "Prod_1102" | New-HPOVServerProfileConnection -ConnectionID 2 -Name 'Prod-1102' -PortId "Mezz 3:2-c"
+    $Eth1              = Get-HPOVNetworkSet -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 1 -Name 'Prod-NetworkSet-1' -PortId "Mezz 3:1-c"
+    $Eth2              = Get-HPOVNetworkset -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 2 -Name 'Prod-NetworkSet-2' -PortId "Mezz 3:2-c"
     $FC1               = Get-HPOVNetwork -Name 'SAN A FC' | New-HPOVServerProfileConnection -connectionId 3
     $FC2               = Get-HPOVNetwork -Name 'SAN B FC' | New-HPOVServerProfileConnection -connectionId 4
     $LogicalDisk       = New-HPOVServerProfileLogicalDisk -Name "SAS RAID5 SSD" -RAID RAID5 -NumberofDrives 3 -DriveType SASSSD -Bootable $True
@@ -439,8 +439,8 @@ function Create_Server_Profile_Template_SY480_Gen9_ESX_SAN_Boot
 
     $SHT               = Get-HPOVServerHardwareTypes -Name "SY 480 Gen9 2" -ErrorAction Stop
     $EnclGroup         = Get-HPOVEnclosureGroup -Name "EG-Synergy-Local" -ErrorAction Stop
-    $Eth1              = Get-HPOVNetwork -Name "Prod_1101" | New-HPOVServerProfileConnection -ConnectionID 1 -Name 'Prod-1101' -PortId "Mezz 3:1-c"
-    $Eth2              = Get-HPOVNetwork -Name "Prod_1102" | New-HPOVServerProfileConnection -ConnectionID 2 -Name 'Prod-1102' -PortId "Mezz 3:2-c"
+    $Eth1              = Get-HPOVNetworkSet -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 1 -Name 'Prod-NetworkSet-1' -PortId "Mezz 3:1-c"
+    $Eth2              = Get-HPOVNetworkset -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 2 -Name 'Prod-NetworkSet-2' -PortId "Mezz 3:2-c"
     $FC1               = Get-HPOVNetwork -Name 'SAN A FC' | New-HPOVServerProfileConnection -ConnectionID 3 -Bootable -Priority Primary -BootVolumeSource ManagedVolume -ConnectionType FibreChannel
     $FC2               = Get-HPOVNetwork -Name 'SAN B FC' | New-HPOVServerProfileConnection -ConnectionID 4 -Bootable -Priority Secondary -BootVolumeSource ManagedVolume -ConnectionType FibreChannel
     $StoragePool       = Get-HPOVStoragePool -Name FST_CPG1 -StorageSystem ThreePAR-1 -ErrorAction Stop
@@ -498,8 +498,8 @@ function Create_Server_Profile_Template_SY480_Gen10_ESX_SAN_Boot
 
     $SHT               = Get-HPOVServerHardwareTypes -Name "SY 480 Gen10 1" -ErrorAction Stop
     $EnclGroup         = Get-HPOVEnclosureGroup -Name "EG-Synergy-Local" -ErrorAction Stop
-    $Eth1              = Get-HPOVNetwork -Name "Prod_1101" | New-HPOVServerProfileConnection -ConnectionID 1 -Name 'Prod-1101' -PortId "Mezz 3:1-c"
-    $Eth2              = Get-HPOVNetwork -Name "Prod_1102" | New-HPOVServerProfileConnection -ConnectionID 2 -Name 'Prod-1102' -PortId "Mezz 3:2-c"
+    $Eth1              = Get-HPOVNetworkSet -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 1 -Name 'Prod-NetworkSet-1' -PortId "Mezz 3:1-c"
+    $Eth2              = Get-HPOVNetworkset -Name "Prod" | New-HPOVServerProfileConnection -ConnectionID 2 -Name 'Prod-NetworkSet-2' -PortId "Mezz 3:2-c"
     $FC1               = Get-HPOVNetwork -Name 'SAN A FC' | New-HPOVServerProfileConnection -ConnectionID 3 -Bootable -Priority Primary -BootVolumeSource ManagedVolume -ConnectionType FibreChannel
     $FC2               = Get-HPOVNetwork -Name 'SAN B FC' | New-HPOVServerProfileConnection -ConnectionID 4 -Bootable -Priority Secondary -BootVolumeSource ManagedVolume -ConnectionType FibreChannel
     $StoragePool       = Get-HPOVStoragePool -Name FST_CPG1 -StorageSystem ThreePAR-2 -ErrorAction Stop

--- a/Populate_HPE_Synergy.ps1
+++ b/Populate_HPE_Synergy.ps1
@@ -68,7 +68,8 @@ function Configure_SAN_Managers {
 
 function Configure_Networks {
     Write-Output "Adding IPv4 Subnets" | Timestamp
-    New-HPOVAddressPoolSubnet -Domain "mgmt.lan" -Gateway $prod_gateway -NetworkId $prod_subnet -SubnetMask $prod_mask
+    #New-HPOVAddressPoolSubnet -Domain "mgmt.lan" -Gateway $prod_gateway -NetworkId $prod_subnet -SubnetMask $prod_mask
+    Get-HPOVAddressPoolSubnet -NetworkId $prod_subnet | Set-HPOVAddressPoolSubnet -Domain "mgmt.lan" 
     New-HPOVAddressPoolSubnet -Domain "deployment.lan" -Gateway $deploy_gateway -NetworkId $deploy_subnet -SubnetMask $deploy_mask
 
     Write-Output "Adding IPv4 Address Pool Ranges" | Timestamp
@@ -661,7 +662,7 @@ if (Test-Path $config_file) {
     }
 }
 else {
-    Write-Output "Configuration file '$config_file' not found.  Exiting." | Timestamp
+    Write-warning "Configuration file '$config_file' not found.  Exiting."  | Timestamp
     Exit
 }
 

--- a/Populate_HPE_Synergy.ps1
+++ b/Populate_HPE_Synergy.ps1
@@ -652,7 +652,7 @@ filter Timestamp { "$(Get-Date -Format G): $_" }
 # Process variables in the Populate_HPE_Synergy-Params.txt file.
 #
 ##########################################################################
-New-Variable -Name config_file -Value $PSScriptRoot\Populate_HPE_Synergy-Params.txt -Scope Global -Force
+New-Variable -Name config_file -Value .\Populate_HPE_Synergy-Params.txt -Scope Global -Force
 
 if (Test-Path $config_file) {
     Get-Content $config_file | Where-Object { !$_.StartsWith("#") } | Foreach-Object {


### PR DESCRIPTION
Hi Dave,

I am about to release a new document: Building your own Synergy demonstration environment using Oracle VM VirtualBox and Windows Subsystem for Linux on your own laptop which will Include Postman, PowerShell, Python and Ansibles scenarios.

In my document I make reference to your excellent Populate HPE Synergy GitHub repo to create the DCS configuration.

The reason I am contacting you is that I would like to know if you could make a tiny change on the way you define your SPT? 

As you know, one of the best practices is to try to make the best use of Network Set in Server Profiles. It incredibly helps to populate new VLANs to all Server Profiles without having to visit each SP, etc. This is a common practice that I would like to see in your script examples. 

Also in my document, I am using several Infra-as-code demo scenarios where Network Set is required.